### PR TITLE
Add Background tasks for running bot client

### DIFF
--- a/backend/app/core/background_runner.py
+++ b/backend/app/core/background_runner.py
@@ -2,6 +2,7 @@ import asyncio
 
 from app.core.bot import BaseBotClient
 from app.core.config import settings
+from app.core.sessions import redis_session_storage
 
 
 class MatrixBotBackgroundRunner:
@@ -11,6 +12,8 @@ class MatrixBotBackgroundRunner:
 
     async def start_bot(self):
         try:
+            # Fetch next batch token stored in redis
+            self.client.next_batch = redis_session_storage["next_batch_token"]
             await self.client.login()
             await self.client.sync_forever(
                 30000,
@@ -30,6 +33,9 @@ class MatrixBotBackgroundRunner:
         self.background_task = asyncio.create_task(self.start_bot())
 
     async def cancel_background_task(self):
+        # Store next batch token in redis
+        redis_session_storage["next_batch_token"] = self.client.next_batch
+
         self.background_task.cancel()
         print(f"Background Task is cancelled")
 

--- a/backend/app/core/background_runner.py
+++ b/backend/app/core/background_runner.py
@@ -12,15 +12,6 @@ class BackgroundRunner:
 
     async def start_bot(self):
         try:
-            with open(settings.matrix_bot.next_batch_token_file, "r") as f:
-                data = json.load(f)
-                self.client.next_batch = data["next_batch_token"]
-        except IOError:
-            print(f"Couldn't load next batch token from file.")
-        except json.JSONDecodeError:
-                print("Couldn't read JSON file; overwriting")
-
-        try:
             await self.client.login()
             await self.client.sync_forever(
                 30000,
@@ -39,16 +30,6 @@ class BackgroundRunner:
     async def cancel_background_task(self):
         self.background_task.cancel()
         print(f"Background Task is cancelled")
-        try:
-            with open(settings.matrix_bot.next_batch_token_file, "w") as f:
-                json.dump(
-                    {
-                        "next_batch_token": self.client.next_batch,
-                    },
-                    f,
-                )
-        except IOError as err:
-            print(f"Couldn't load next batch token from file. Error: {err}")
 
 
 runner = BackgroundRunner()

--- a/backend/app/core/background_runner.py
+++ b/backend/app/core/background_runner.py
@@ -5,7 +5,7 @@ from app.core.bot import BaseBotClient
 from app.core.config import settings
 
 
-class BackgroundRunner:
+class MatrixBotBackgroundRunner:
     def __init__(self):
         self.client = BaseBotClient.get_bot_client()
         self.background_task = None
@@ -32,4 +32,4 @@ class BackgroundRunner:
         print(f"Background Task is cancelled")
 
 
-runner = BackgroundRunner()
+matrix_bot_runner = MatrixBotBackgroundRunner()

--- a/backend/app/core/background_runner.py
+++ b/backend/app/core/background_runner.py
@@ -1,0 +1,54 @@
+import asyncio
+import json
+
+from app.core.bot import BaseBotClient
+from app.core.config import settings
+
+
+class BackgroundRunner:
+    def __init__(self):
+        self.client = BaseBotClient.get_bot_client()
+        self.background_task = None
+
+    async def start_bot(self):
+        try:
+            with open(settings.matrix_bot.next_batch_token_file, "r") as f:
+                data = json.load(f)
+                self.client.next_batch = data["next_batch_token"]
+        except IOError:
+            print(f"Couldn't load next batch token from file.")
+        except json.JSONDecodeError:
+                print("Couldn't read JSON file; overwriting")
+
+        try:
+            await self.client.login()
+            await self.client.sync_forever(
+                30000,
+                since=self.client.next_batch,
+                full_state=True,
+                loop_sleep_time=2000,
+            )
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            await self.client.close()
+
+    def create_background_task(self):
+        print("Background task has started")
+        self.background_task = asyncio.create_task(self.start_bot())
+
+    async def cancel_background_task(self):
+        self.background_task.cancel()
+        print(f"Background Task is cancelled")
+        try:
+            with open(settings.matrix_bot.next_batch_token_file, "w") as f:
+                json.dump(
+                    {
+                        "next_batch_token": self.client.next_batch,
+                    },
+                    f,
+                )
+        except IOError as err:
+            print(f"Couldn't load next batch token from file. Error: {err}")
+
+
+runner = BackgroundRunner()

--- a/backend/app/core/background_runner.py
+++ b/backend/app/core/background_runner.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 
 from app.core.bot import BaseBotClient
 from app.core.config import settings
@@ -7,7 +6,7 @@ from app.core.config import settings
 
 class MatrixBotBackgroundRunner:
     def __init__(self):
-        self.client = BaseBotClient.get_bot_client()
+        self.client = BaseBotClient(homeserver=settings.matrix_bot.homeserver)
         self.background_task = None
 
     async def start_bot(self):
@@ -20,7 +19,10 @@ class MatrixBotBackgroundRunner:
                 loop_sleep_time=2000,
             )
             await asyncio.sleep(1)
-        except asyncio.CancelledError:
+        except (asyncio.CancelledError, ValueError) as err:
+            # Handles the ValueError received from BaseBotClient login function
+            if isinstance(err, ValueError):
+                print(err)
             await self.client.close()
 
     def create_background_task(self):

--- a/backend/app/core/bot.py
+++ b/backend/app/core/bot.py
@@ -1,0 +1,117 @@
+import asyncio
+import json
+import os
+import sys
+from asyncio import exceptions
+from typing import Optional
+
+from nio import (
+    AsyncClient,
+    AsyncClientConfig,
+    InviteEvent,
+    LoginResponse,
+    MatrixRoom,
+    RoomMessageText,
+)
+
+from app.core.config import settings
+
+
+class BaseBotClient(AsyncClient):
+    def __init__(
+        self,
+        homeserver: str,
+        user: str = "",
+        device_id: Optional[str] = "",
+        store_path: Optional[str] = "",
+        config: Optional[AsyncClientConfig] = None,
+        ssl: Optional[bool] = None,
+        proxy: Optional[str] = None,
+    ):
+        super().__init__(homeserver, user, device_id, store_path, config, ssl, proxy)
+
+        self.password = None
+
+        # auto-join room invites
+        self.add_event_callback(self.cb_autojoin_room, InviteEvent)
+
+        # print all the messages we receive
+        self.add_event_callback(self.cb_print_messages, RoomMessageText)
+
+    async def login(self) -> None:
+        # Log in either using the session details file or the username, password (if the file dosen't exist)
+        if os.path.exists(settings.matrix_bot.session_details_file) and os.path.isfile(
+            settings.matrix_bot.session_details_file
+        ):
+            try:
+                with open(settings.matrix_bot.session_details_file, "r") as f:
+                    config = json.load(f)
+                    self.access_token = config["access_token"]
+                    self.user_id = config["user_id"]
+                    self.device_id = config["device_id"]
+
+            except IOError as err:
+                print(f"Couldn't load session from file. Logging in. Error: {err}")
+            except json.JSONDecodeError:
+                print("Couldn't read JSON file; overwriting")
+
+        # If the previous session is not stored, we'll log in with a password
+        if not self.user_id or not self.access_token or not self.device_id:
+            if self.password is None:
+                print("Password is blank")
+                sys.exit(1)
+
+            resp = await super().login(self.password, device_name=self.device_id)
+
+            if isinstance(resp, LoginResponse):
+                self.__write_details_to_disk(resp)
+            else:
+                print(f"Failed to log in: {resp}")
+                sys.exit(1)
+
+    async def cb_autojoin_room(self, room: MatrixRoom, event: InviteEvent):
+        # Callback to automatically join a Matrix room on invite.
+        await self.join(room.room_id)
+
+    async def cb_print_messages(self, room: MatrixRoom, event: RoomMessageText):
+        # Callback to print all received messages to stdout.
+        print(f"{room.display_name} @{room.user_name(event.sender)}: {event.body}")
+
+    async def send_message_to_room(self, room_id, msg):
+        try:
+            await self.room_send(
+                room_id=room_id,
+                message_type="m.room.message",
+                content={
+                    "msgtype": "m.text",
+                    "body": f"{msg}",
+                },
+            )
+        except exceptions as err:
+            print(err)
+
+    @staticmethod
+    def __write_details_to_disk(resp: LoginResponse) -> None:
+        """Writes login details to disk so that we can restore our session later
+        without logging in again and creating a new device ID.
+        """
+        with open(settings.matrix_bot.session_details_file, "w") as f:
+            json.dump(
+                {
+                    "access_token": resp.access_token,
+                    "device_id": resp.device_id,
+                    "user_id": resp.user_id,
+                },
+                f,
+            )
+
+    @classmethod
+    def get_bot_client(cls):
+        client = BaseBotClient(
+            settings.matrix_bot.homeserver,
+            settings.matrix_bot.user_id,
+            device_id=settings.matrix_bot.device_id,
+        )
+        client.password = settings.matrix_bot.password
+
+        return client

--- a/backend/app/core/bot.py
+++ b/backend/app/core/bot.py
@@ -1,7 +1,3 @@
-import asyncio
-import json
-import os
-import sys
 from asyncio import exceptions
 from typing import Optional
 
@@ -9,7 +5,6 @@ from nio import (
     AsyncClient,
     AsyncClientConfig,
     InviteEvent,
-    LoginResponse,
     MatrixRoom,
     RoomMessageText,
 )

--- a/backend/app/core/bot.py
+++ b/backend/app/core/bot.py
@@ -30,51 +30,20 @@ class BaseBotClient(AsyncClient):
     ):
         super().__init__(homeserver, user, device_id, store_path, config, ssl, proxy)
 
-        self.password = None
-
         # auto-join room invites
         self.add_event_callback(self.cb_autojoin_room, InviteEvent)
 
-        # print all the messages we receive
+        # print all the messages we receive to console
         self.add_event_callback(self.cb_print_messages, RoomMessageText)
 
     async def login(self) -> None:
-        # Log in either using the session details file or the username, password (if the file dosen't exist)
-        if os.path.exists(settings.matrix_bot.session_details_file) and os.path.isfile(
-            settings.matrix_bot.session_details_file
-        ):
-            try:
-                with open(settings.matrix_bot.session_details_file, "r") as f:
-                    config = json.load(f)
-                    self.access_token = config["access_token"]
-                    self.user_id = config["user_id"]
-                    self.device_id = config["device_id"]
-
-            except IOError as err:
-                print(f"Couldn't load session from file. Logging in. Error: {err}")
-            except json.JSONDecodeError:
-                print("Couldn't read JSON file; overwriting")
-
-        # If the previous session is not stored, we'll log in with a password
-        if not self.user_id or not self.access_token or not self.device_id:
-            if self.password is None:
-                print("Password is blank")
-                sys.exit(1)
-
-            resp = await super().login(self.password, device_name=self.device_id)
-
-            if isinstance(resp, LoginResponse):
-                self.__write_details_to_disk(resp)
-            else:
-                print(f"Failed to log in: {resp}")
-                sys.exit(1)
+        # Log in using the access token provided in config.yml
+        self.access_token = settings.matrix_bot.access_token
 
     async def cb_autojoin_room(self, room: MatrixRoom, event: InviteEvent):
-        # Callback to automatically join a Matrix room on invite.
         await self.join(room.room_id)
 
     async def cb_print_messages(self, room: MatrixRoom, event: RoomMessageText):
-        # Callback to print all received messages to stdout.
         print(f"{room.display_name} @{room.user_name(event.sender)}: {event.body}")
 
     async def send_message_to_room(self, room_id, msg):
@@ -90,28 +59,11 @@ class BaseBotClient(AsyncClient):
         except exceptions as err:
             print(err)
 
-    @staticmethod
-    def __write_details_to_disk(resp: LoginResponse) -> None:
-        """Writes login details to disk so that we can restore our session later
-        without logging in again and creating a new device ID.
-        """
-        with open(settings.matrix_bot.session_details_file, "w") as f:
-            json.dump(
-                {
-                    "access_token": resp.access_token,
-                    "device_id": resp.device_id,
-                    "user_id": resp.user_id,
-                },
-                f,
-            )
-
     @classmethod
     def get_bot_client(cls):
         client = BaseBotClient(
             settings.matrix_bot.homeserver,
             settings.matrix_bot.user_id,
-            device_id=settings.matrix_bot.device_id,
         )
-        client.password = settings.matrix_bot.password
 
         return client

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -16,10 +16,7 @@ class ServerSessionsSettings(BaseSettings):
 class MatrixBotSettings(BaseSettings):
     homeserver: str
     user_id: str
-    password: str
-    device_id: str
-    session_details_file: str
-    next_batch_token_file: str
+    access_token: str
 
 
 class Settings(BaseSettings):

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -24,7 +24,7 @@ class MatrixBotSettings(BaseSettings):
     def validate(cls, values):
         homeserver = values.get("homeserver")
 
-        if re.search(r"https?://", homeserver) is None:
+        if re.search(r"(https|http)?://", homeserver) is None:
             raise ValueError("Invalid homeserver")
 
         return values

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -13,10 +13,20 @@ class ServerSessionsSettings(BaseSettings):
     expires_in: int
 
 
+class MatrixBotSettings(BaseSettings):
+    homeserver: str
+    user_id: str
+    password: str
+    device_id: str
+    session_details_file: str
+    next_batch_token_file: str
+
+
 class Settings(BaseSettings):
 
     redis: RedisSettings
     server_sessions: ServerSessionsSettings
+    matrix_bot: MatrixBotSettings
 
     @classmethod
     def from_yaml(cls, path_to_file):

--- a/backend/app/core/sessions.py
+++ b/backend/app/core/sessions.py
@@ -49,7 +49,7 @@ class RedisSessionStorage:
         return sessionId
 
 
-redis_session_storage = RedisSessionStorage()
+session_storage = RedisSessionStorage()
 
 
 """
@@ -60,14 +60,14 @@ to interact with the redis database
 
 class SessionCookie:
     def __init__(self):
-        self.sessions_storage = redis_session_storage
+        self.session_storage = session_storage
         self.session_key = settings.server_sessions.session_key
         self.expires_in = settings.server_sessions.expires_in
 
     def create_session(self, request: Request, response: Response):
-        session_id = self.sessions_storage.generate_session_id()
+        session_id = self.session_storage.generate_session_id()
         data = {"matrix_user": None, "access_token": None}
-        self.sessions_storage.set_item_with_expiry_time(
+        self.session_storage.set_item_with_expiry_time(
             key=session_id, value=data, expires_in=self.expires_in
         )
 
@@ -85,11 +85,11 @@ class SessionCookie:
 
     def get_session(self, request: Request):
         session_id = self.get_session_id(request)
-        return self.sessions_storage[session_id]
+        return self.session_storage[session_id]
 
     def set_session(self, request: Request, response: Response, data):
         session_id = self.get_session_id(request)
-        self.sessions_storage.set_item_with_expiry_time(
+        self.session_storage.set_item_with_expiry_time(
             key=session_id, value=data, expires_in=self.expires_in
         )
         return response
@@ -97,7 +97,7 @@ class SessionCookie:
     def delete_session(self, request: Request, response: Response):
         session_id = self.get_session_id(request)
         if session_id:
-            del self.sessions_storage[session_id]
+            del self.session_storage[session_id]
             response.delete_cookie(self.session_key)
 
         return response

--- a/backend/app/core/sessions.py
+++ b/backend/app/core/sessions.py
@@ -28,7 +28,6 @@ class RedisSessionStorage:
         return raw and pickle.loads(raw)
 
     def __setitem__(self, key: str, value: Any):
-        expireTime = timedelta(hours=1)
         self.client.set(
             key,
             pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,17 +1,17 @@
 from fastapi import Depends, FastAPI
 
 from app.api import api
-from app.core.background_runner import runner
+from app.core.background_runner import matrix_bot_runner
 
 app = FastAPI(docs_url="/api/docs", redoc_url="/api/redoc", openapi_url="/api/openapi")
 
 @app.on_event('startup')
 async def app_startup():
-    runner.create_background_task()
+    matrix_bot_runner.create_background_task()
 
 @app.on_event('shutdown')
 async def app_shutdown():
-    await runner.cancel_background_task()
+    await matrix_bot_runner.cancel_background_task()
 
 @app.get("/api")
 async def root():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,13 +5,16 @@ from app.core.background_runner import matrix_bot_runner
 
 app = FastAPI(docs_url="/api/docs", redoc_url="/api/redoc", openapi_url="/api/openapi")
 
-@app.on_event('startup')
+
+@app.on_event("startup")
 async def app_startup():
     matrix_bot_runner.create_background_task()
 
-@app.on_event('shutdown')
+
+@app.on_event("shutdown")
 async def app_shutdown():
     await matrix_bot_runner.cancel_background_task()
+
 
 @app.get("/api")
 async def root():

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,17 @@
 from fastapi import Depends, FastAPI
 
 from app.api import api
+from app.core.background_runner import runner
 
 app = FastAPI(docs_url="/api/docs", redoc_url="/api/redoc", openapi_url="/api/openapi")
 
+@app.on_event('startup')
+async def app_startup():
+    runner.create_background_task()
+
+@app.on_event('shutdown')
+async def app_shutdown():
+    await runner.cancel_background_task()
 
 @app.get("/api")
 async def root():

--- a/backend/config.yml
+++ b/backend/config.yml
@@ -12,12 +12,6 @@ server_sessions:
   expires_in: 3600
 
 matrix_bot:
-  # Contains details related to the Bot account
-  #
-  homeserver: https://matrix.org
+  homeserver: "https://matrix.org"
   user_id: "@matrix-cerberus:matrix.org"
-  password: "some_password"
-  device_id: "your_device"
-
-  session_details_file: "credentials_bot.json"
-  next_batch_token_file: "next_batch_token.json"
+  access_token: some_access_token

--- a/backend/config.yml
+++ b/backend/config.yml
@@ -10,3 +10,14 @@ server_sessions:
   #
   session_key: sessionID  
   expires_in: 3600
+
+matrix_bot:
+  # Contains details related to the Bot account
+  #
+  homeserver: https://matrix.org
+  user_id: "@matrix-cerberus:matrix.org"
+  password: "some_password"
+  device_id: "your_device"
+
+  session_details_file: "credentials_bot.json"
+  next_batch_token_file: "next_batch_token.json"

--- a/backend/config.yml
+++ b/backend/config.yml
@@ -13,5 +13,4 @@ server_sessions:
 
 matrix_bot:
   homeserver: "https://matrix.org"
-  user_id: "@matrix-cerberus:matrix.org"
   access_token: some_access_token

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,6 +20,7 @@ iniconfig==1.1.1
 isort==5.10.1
 makefun==1.13.1
 mypy-extensions==0.4.3
+nio==3.4.2
 packaging==21.3
 passlib==1.7.4
 pathspec==0.9.0
@@ -32,8 +33,10 @@ PyJWT==2.3.0
 pyparsing==3.0.9
 pytest==7.1.2
 python-multipart==0.0.5
+PyYAML==6.0
 redis==4.3.1
 requests==2.27.1
+safepickle==0.2.0
 six==1.16.0
 sniffio==1.2.0
 starlette==0.19.1


### PR DESCRIPTION
The Bot Client runs asynchronously in the same event loop that FastAPI uses for its API endpoints.  

Currently, the bot can 
 - Send a message to a room
 - Join invited rooms automatically by listening to room invite events.
 - Print room messages events to console.

The background task when cancelled saves the session details of the bot (access tokens, device ID) to avoid creating a new session every time it logs in. 