### PR TITLE
Render webpages on login and use context hooks to manage User Id

### DIFF
--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Request
 from starlette.responses import JSONResponse, RedirectResponse
 
 from app.api.deps import fastapi_sessions
+from app.core.background_runner import matrix_bot_runner
 from app.core.models import ServerSessionData
 
 router = APIRouter()
@@ -10,6 +11,13 @@ router = APIRouter()
 @router.get("/")
 async def message_users():
     return {"message": "Hello User!!!"}
+
+
+@router.get("/room-list")
+async def get_room_list(request: Request):
+    session_data = fastapi_sessions.get_session(request)
+    resp = await matrix_bot_runner.client.get_rooms_with_mod_permissions(session_data.matrix_user)
+    return JSONResponse({"content": resp})
 
 
 @router.post("/logout")

--- a/backend/app/core/bot.py
+++ b/backend/app/core/bot.py
@@ -95,3 +95,16 @@ class BaseBotClient(AsyncClient):
                 self.room_to_external_url_mapping[value.room_id].temporary.add(url_code)
             else:
                 self.room_to_external_url_mapping[value.room_id].permanent = url_code
+
+    async def get_rooms_with_mod_permissions(self, user_id: str):
+        rooms_with_mod_permissions = {}
+        for room_id, room_object in self.rooms.items():
+            # Check if bot has permissions to kick and invite
+            if room_object.power_levels.can_user_invite(
+                self.user_id
+            ) and room_object.power_levels.can_user_kick(self.user_id):
+                # Check if user is a member of the room
+                if user_id in room_object.users and not room_object.users[user_id].invited:
+                    if room_object.power_levels.get_user_level(user_id) >= 50:
+                        rooms_with_mod_permissions[room_id] = room_object.named_room_name()
+        return rooms_with_mod_permissions

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,7 +2,6 @@ import './App.css';
 import React, { useState } from 'react';
 import {Routes, Route, BrowserRouter, Outlet} from "react-router-dom";
 import AccountSettings from './Pages/AccountSettings';
-import NavBar from './Components/NavBar';
 import RoomSettings from './Pages/RoomSettings';
 import ServerSettings from './Pages/ServerSettings';
 import Login from './Pages/Login';
@@ -12,17 +11,7 @@ import ExternalUrl from './Pages/ExternalUrl';
 import CustomRouter from './Components/CustomRouter';
 import history from './HelperFunctions/customHistory';
 import { GlobalContext } from './GlobalContext';
-
-function LayoutsWithNavbar() {
-  return (
-    <>
-      <NavBar />
-
-      {/* This Outlet is the place in which react-router will render your components that you need with the navbar */}
-      <Outlet />
-    </>
-  );
-}
+import LayoutsWithNavbar from './Components/LayoutsWithNavbar';
 
 export default function App() {
   const [matrixUserId, setMatrixUserId] = useState('@kuries:matrix.org');
@@ -32,7 +21,7 @@ export default function App() {
     <GlobalContext.Provider
           value = {{matrixUserId, setMatrixUserId}}>
       <Routes>
-          <Route path='/' element={<LayoutsWithNavbar/>}>
+          <Route element={<LayoutsWithNavbar/>}>
             <Route path="/" element={<AccountSettings />} />
             <Route path="/room-settings" element={<RoomSettings />} />
             <Route path="/server-settings" element={<ServerSettings />} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import './App.css';
-import React from 'react';
+import React, { useState } from 'react';
 import {Routes, Route, BrowserRouter, Outlet} from "react-router-dom";
 import AccountSettings from './Pages/AccountSettings';
 import NavBar from './Components/NavBar';
@@ -11,6 +11,7 @@ import ErrorPage from './Pages/ErrorPage';
 import ExternalUrl from './Pages/ExternalUrl';
 import CustomRouter from './Components/CustomRouter';
 import history from './HelperFunctions/customHistory';
+import { GlobalContext } from './GlobalContext';
 
 function LayoutsWithNavbar() {
   return (
@@ -24,20 +25,25 @@ function LayoutsWithNavbar() {
 }
 
 export default function App() {
+  const [matrixUserId, setMatrixUserId] = useState('@kuries:matrix.org');
+
   return (
     <CustomRouter history={history}>
+    <GlobalContext.Provider
+          value = {{matrixUserId, setMatrixUserId}}>
       <Routes>
-        <Route path='/' element={<LayoutsWithNavbar/>}>
-          <Route path="/" element={<AccountSettings />} />
-          <Route path="/room-settings" element={<RoomSettings />} />
-          <Route path="/server-settings" element={<ServerSettings />} />
-        </Route>
+          <Route path='/' element={<LayoutsWithNavbar/>}>
+            <Route path="/" element={<AccountSettings />} />
+            <Route path="/room-settings" element={<RoomSettings />} />
+            <Route path="/server-settings" element={<ServerSettings />} />
+          </Route>
 
         <Route path="/i/:url_code" element={<ExternalUrl />} />
         <Route path="/login" element={<Login />} />
         <Route path="/login-success" element={<LoginSuccess/>} />
         <Route path="*" element={<ErrorPage/>} />
       </Routes>
+    </GlobalContext.Provider>
     </CustomRouter>
   )
 };

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,9 +12,10 @@ import CustomRouter from './Components/CustomRouter';
 import history from './HelperFunctions/customHistory';
 import { GlobalContext } from './GlobalContext';
 import LayoutsWithNavbar from './Components/LayoutsWithNavbar';
+import Logout from './Pages/Logout';
 
 export default function App() {
-  const [matrixUserId, setMatrixUserId] = useState('@kuries:matrix.org');
+  const [matrixUserId, setMatrixUserId] = useState('');
 
   return (
     <CustomRouter history={history}>
@@ -25,6 +26,7 @@ export default function App() {
             <Route path="/" element={<AccountSettings />} />
             <Route path="/room-settings" element={<RoomSettings />} />
             <Route path="/server-settings" element={<ServerSettings />} />
+            <Route path="/logout" element={<Logout />} />
           </Route>
 
         <Route path="/i/:url_code" element={<ExternalUrl />} />

--- a/frontend/src/Components/LayoutsWithNavbar.js
+++ b/frontend/src/Components/LayoutsWithNavbar.js
@@ -1,0 +1,32 @@
+import axios from 'axios';
+import React, { useContext, useEffect } from 'react'
+import { Outlet, useNavigate } from 'react-router-dom';
+import { GlobalContext } from '../GlobalContext';
+import NavBar from './NavBar';
+
+export default function LayoutsWithNavbar() {
+  const {setMatrixUserId} = useContext(GlobalContext);
+  const navigate = useNavigate();
+
+  useEffect( () => {
+      const fetchCurrentUser = async () => {
+        const resp = await axios.get('api/current-user');
+        console.log(resp.data);
+        if(resp.data.matrix_user_id !== null){
+            const user_id = resp.data.matrix_user_id;
+            setMatrixUserId(user_id);
+        }
+        else {
+          navigate('/login');
+        }
+      }
+      fetchCurrentUser();
+  }, []);
+
+  return (
+    <>
+      <NavBar />
+      <Outlet />
+    </>
+  );
+}

--- a/frontend/src/Components/NavBar.js
+++ b/frontend/src/Components/NavBar.js
@@ -1,9 +1,11 @@
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { GlobalContext } from '../GlobalContext';
 import AccountDropdown from './AccountDropdown';
 
 export default function NavBar() {
     const [isOpen, setIsOpen] = useState(false);
+    const {matrixUserId, setMatrixUserId} = useContext(GlobalContext);
 
     function handleClick() {
         setIsOpen(!isOpen);

--- a/frontend/src/Components/NavBar.js
+++ b/frontend/src/Components/NavBar.js
@@ -5,7 +5,7 @@ import AccountDropdown from './AccountDropdown';
 
 export default function NavBar() {
     const [isOpen, setIsOpen] = useState(false);
-    const {matrixUserId, setMatrixUserId} = useContext(GlobalContext);
+    const {matrixUserId} = useContext(GlobalContext);
 
     function handleClick() {
         setIsOpen(!isOpen);
@@ -43,7 +43,7 @@ export default function NavBar() {
                 <div className='px-4 py-5 border-t border-gray-800 sm:hidden'>
                     <div className='mb-3 flex items-center'>
                         <img alt="..." className='h-6 w-6 border-2 border-gray-600 rounded-full object-cover' src={require('../assets/img/user.svg').default} />
-                        <span className='ml-3 font-semibold text-white'>kuries</span>
+                        <span className='ml-3 font-semibold text-white'>{matrixUserId}</span>
                     </div>
                     <Link to='/login' className='block mt-2 text-gray-400 hover:text-white'>Log in</Link>
                     <Link to='/logout' className='block mt-2 text-gray-400 hover:text-white'>Sign Out</Link>

--- a/frontend/src/GlobalContext.js
+++ b/frontend/src/GlobalContext.js
@@ -1,0 +1,6 @@
+import React, { createContext } from 'react'
+
+export const GlobalContext = createContext({
+    matrixUserId: "",
+    setMatrixUserId: () => {}
+});

--- a/frontend/src/Pages/AccountSettings.js
+++ b/frontend/src/Pages/AccountSettings.js
@@ -6,6 +6,7 @@ import { GlobalContext } from '../GlobalContext';
  */
 export default function AccountSettings() {
 	const {matrixUserId} = useContext(GlobalContext);
+	const homeServer = localStorage.getItem('homeServer');
 	return (
 		<div>
 			<div className="flex items-center w-full h-48 py-5 shadow-lg bg-dark-eye" >
@@ -42,7 +43,7 @@ export default function AccountSettings() {
 									Homeserver
 								</div>
 								<div className='w-2/3 px-2 text-gray-600'>
-									matrix.org
+									{homeServer}
 								</div>
 							</div>
 
@@ -70,7 +71,7 @@ export default function AccountSettings() {
 									</div>
 								</div>
 								<div className='inline-block px-2 w-1/3 text-gray-600'>
-									Connected as kuries
+									Connected as GitHub user.
 								</div>
 								<div className='flex justify-end mx-2 w-1/3'>
 									<span className='px-2 text-blue-600 hover:shadow-md'>
@@ -100,7 +101,7 @@ export default function AccountSettings() {
 									</div>
 								</div>
 								<div className='w-1/3 px-2 text-gray-600'>
-									Connected as Binesh
+									Connected as Patreon user
 								</div>
 								<div className='flex justify-end mx-2 w-1/3'>
 									<span className='px-2 text-blue-600 hover:shadow-md'>

--- a/frontend/src/Pages/AccountSettings.js
+++ b/frontend/src/Pages/AccountSettings.js
@@ -1,10 +1,11 @@
-import React from 'react'
+import React, { useContext } from 'react'
+import { GlobalContext } from '../GlobalContext';
 
 /**
  * The default web page where an authorized matrix user can edit their third-party account connections.
  */
 export default function AccountSettings() {
-
+	const {matrixUserId} = useContext(GlobalContext);
 	return (
 		<div>
 			<div className="flex items-center w-full h-48 py-5 shadow-lg bg-dark-eye" >
@@ -30,7 +31,7 @@ export default function AccountSettings() {
 									Matrix ID
 								</div>
 								<div className='w-2/3 px-2 text-gray-600'>
-									Kuries
+									{matrixUserId}
 								</div>
 							</div>
 

--- a/frontend/src/Pages/Logout.js
+++ b/frontend/src/Pages/Logout.js
@@ -1,0 +1,24 @@
+import axios from 'axios'
+import React, { useContext, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom';
+import { GlobalContext } from '../GlobalContext';
+
+export default function Logout() {
+    const navigate = useNavigate();
+    const {setMatrixUserId} = useContext(GlobalContext);
+    useEffect( ()=> {
+        async function signOutUser() {
+            axios.post('api/users/logout')
+            .then( (resp) => {
+                console.log(resp);
+                setMatrixUserId('');
+                navigate('/login');
+            });
+        }
+        signOutUser();
+    }, [])
+    return (
+        <>
+        </>
+    )
+}

--- a/frontend/src/Pages/RoomSettings.js
+++ b/frontend/src/Pages/RoomSettings.js
@@ -1,49 +1,37 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from "prop-types"
+import axios from '../HelperFunctions/customAxios'
 
-const TableHeader = ({ values }) => {
+const TableHeader = ({ colValue }) => {
   return (
-    <tr>
-      {values.map( (col) => {
-        return (
-          <th scope="col" className="text-md font-medium text-gray-900 px-6 py-4 text-left" key={col}>
-            {col}
-          </th>
-        )
-      })}
-    </tr>
+      <th scope="col" className="text-md font-medium text-gray-900 px-6 py-4 text-left">
+        {colValue}
+      </th>
   )
 }
 
 TableHeader.propTypes = {
-  values: PropTypes.arrayOf(PropTypes.string)
+  colValue: PropTypes.string
 }
 
-const TableRows =  ({ values }) => {
+const TableRows =  ({ rowValue }) => {
   return (
-    <>
-      {values.map( (row) => {
-        return (
-          // key is used to uniquely identify a child item
-          <tr className="border-b transition duration-300 ease-in-out hover:bg-gray-200" key={row.roomId}>
-            <td className="px-6 py-4 whitespace-nowrap text-md font-medium text-gray-900">
-              {row.id}
-            </td>
-            <td className="text-md text-gray-900 font-light px-6 py-4 whitespace-nowrap">
-              {row.roomAlias}
-            </td>
-            <td className="text-md text-gray-900 font-light px-6 py-4 whitespace-nowrap">
-              {row.roomId}
-            </td>
-          </tr>
-        )
-      })}
-    </>
+    <tr className="border-b transition duration-300 ease-in-out hover:bg-gray-200">
+      <td className="px-6 py-4 whitespace-nowrap text-md font-medium text-gray-900">
+        {rowValue.id}
+      </td>
+      <td className="text-md text-gray-900 font-light px-6 py-4 whitespace-nowrap">
+        {rowValue.roomAlias}
+      </td>
+      <td className="text-md text-gray-900 font-light px-6 py-4 whitespace-nowrap">
+        {rowValue.roomId}
+      </td>
+    </tr>
   )
 };
 
 TableRows.propTypes = {
-  values: PropTypes.arrayOf(PropTypes.object)
+  rowValue: PropTypes.object
 }
 
 /**
@@ -52,13 +40,27 @@ TableRows.propTypes = {
  */
 export default function RoomSettings() {
 
-  // Dummy data for tables
   const roomHeaderData = ['#', 'Room Alias', 'Room ID'];
-  const roomBodyData = [
-    {id: 1, roomAlias: "Matrix Cerberus", roomId: "!hMaAAyWsrBAMXEfXso:cadair.com"},
-    {id: 2, roomAlias: "GSoC Interns & Mentors 2022", roomId: "!auFsXYPeEIXfseVOEm:ergaster.org"},
-    {id: 3, roomAlias: "Element Web/Desktop", roomId: "!YTvKGNlinIzlkMTVRl:matrix.org"}
-  ];
+  const [roomBodyData, setRoomBodyData] = useState([]);
+
+  useEffect( () => {
+    async function fetchRoomData() {
+      const resp = await axios.get('api/users/room-list');
+      const data = resp.data.content;
+
+      let roomData = [], index=1;
+      for(let key in data){
+        roomData.push({
+          id: index,
+          roomAlias: data[key],
+          roomId: key
+        })
+        index += 1;
+      }
+      setRoomBodyData(roomData);
+    }
+    fetchRoomData();
+  }, []);
 
   return (
     <div>
@@ -88,10 +90,16 @@ export default function RoomSettings() {
                     <div className="overflow-hidden">
                       <table className="min-w-full">
                         <thead className="bg-gray-300 border-b">
-                          <TableHeader values={roomHeaderData} />
+                          <tr>
+                            {roomHeaderData.map( (colValue) => {
+                              return <TableHeader colValue={colValue} key={colValue}/>
+                            })}
+                          </tr>
                         </thead>
                         <tbody>
-                          <TableRows values={roomBodyData} />
+                          {roomBodyData.map( (rowValue) => {
+                            return <TableRows rowValue={rowValue} key={rowValue.roomId}/>
+                          })}
                         </tbody>
                       </table>
                     </div>


### PR DESCRIPTION
Parent: #26 

- I've used context hooks to pass down `matrixUserId` state variables (it's value and its set method) to all the components which require a NavBar (these are protected routes which require the user to be authenticated).

- The `LayoutsWithNavbar.js` first tries to fetch the current user's matrix id and if it is null, they are redirected back to login.

- The backend tries to compile a list of rooms for the `/api/users/room-list` endpoint based on two conditions:
    -  Bot has moderator permissions for the given room (can invite and kick a default user)
    - User has a power level of more than 50 (default for moderators).
